### PR TITLE
Implanted chest item functionality and surgery

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -6282,7 +6282,8 @@
 
 /mob/living/carbon/human/attack_hand(mob/M)
 	..()
-	src.activate_chest_item_on_attack(M)
+	if (!surgeryCheck(src, M))
+		src.activate_chest_item_on_attack(M)
 	if (M.a_intent in list(INTENT_HARM,INTENT_DISARM,INTENT_GRAB))
 		src.was_harmed(M)
 
@@ -6294,7 +6295,8 @@
 	var/tmp/damage = ((newbloss - oldbloss) + (get_burn_damage() - oldfloss))
 	if (reagents)
 		reagents.physical_shock((newbloss - oldbloss) * 0.15)
-	src.activate_chest_item_on_attack(M)
+	if (!surgeryCheck(src, M))
+		src.activate_chest_item_on_attack(M)
 	if ((damage > 0) || W.force)
 		src.was_harmed(M, W)
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1569,10 +1569,6 @@
 					//		animate(transform = turn(GetPooledMatrix(), -270), time = 1, loop = -1)
 					//		animate(transform = turn(GetPooledMatrix(), -360), time = 1, loop = -1)
 
-					// If there is a chest item, see if its reagents can be dumped into the body
-					//if(src.chest_item != null)
-					//	src.chest_item_dump_reagents_on_flip()
-
 					if (istype(src.loc,/obj/))
 						var/obj/container = src.loc
 						boutput(src, "<span style=\"color:red\">You leap and slam your head against the inside of [container]! Ouch!</span>")
@@ -1906,14 +1902,6 @@
 						// If there is a chest item, see if it can be activated on fart (attack_self)
 						if (src.chest_item != null)
 							src.chest_item_attack_self_on_fart()
-							/*var/obj/item/fartItem = src.chest_item
-							src.show_text("You grunt and squeeze <B>[fartItem]</B> in your chest.")
-							fartItem.attack_self(src)
-							if (src.chest_item_sewn == 0)	// If item isn't sewn in, poop it onto the ground.
-								var/obj/item/outChestItem = src.chest_item
-								outChestItem.set_loc(get_turf(src))
-								src.chest_item = null
-								src.show_text("[fartItem] was shat out, that's got to hurt!")*/
 
 						if (iscluwne(src))
 							playsound(src.loc, 'sound/misc/Poo.ogg', 50, 1)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -537,6 +537,10 @@
 		if (!src.Eat(M, user))
 			return ..()
 
+	if (surgeryCheck(M, user))		// Check for surgery-specific actions
+		insertChestItem(M, user)	// Puting item in patient's chest
+		return
+
 	if (src.flags & SUPPRESSATTACK)
 		logTheThing("combat", user, M, "uses [src] ([type], object name: [initial(name)]) on %target%")
 		return

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -66,6 +66,12 @@
 		total_amt = null
 		return
 
+	attack(mob/M as mob, mob/user as mob)
+		if (surgeryCheck(M, user))
+			insertChestItem(M, user)
+			return
+		..()
+
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (W.cant_drop) return
 		if (can_hold.len)

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -90,13 +90,17 @@
 						blood_data += " | <span style='color:red'><B>Bleeding wounds detected</B></span>"
 					if (7 to INFINITY)
 						blood_data += " | <span style='color:red'><B>Major bleeding wounds detected</B></span>"
-			if (H.implant && H.implant.len > 0)
+			if ((H.implant && H.implant.len > 0) || H.chest_item != null)
 				var/bad_stuff = 0
 				for (var/obj/item/implant/I in H)
 					if (istype(I, /obj/item/implant/projectile))
 						bad_stuff ++
+				if(H.chest_item != null) // If item is in chest, add one
+					bad_stuff ++
 				if (bad_stuff)
 					blood_data += " | <span style='color:red'><B>Foreign object[bad_stuff == 1 ? "" : "s"] detected</B></span>"
+				if(H.chest_item != null) // State that large foreign object is located in chest
+					blood_data += " | <span style=\"color:red\"><B>Sizable foreign object located below sternum</B></span>"
 
 		if (H.pathogens.len)
 			pathogen_data = "<span style='color:red'>Scans indicate the presence of [H.pathogens.len > 1 ? "[H.pathogens.len] " : null]pathogenic bodies.</span>"

--- a/code/procs/surgery.dm
+++ b/code/procs/surgery.dm
@@ -620,6 +620,7 @@
 			var/obj/item/outChestItem = patient.chest_item
 			outChestItem.set_loc(location)
 			patient.chest_item = null
+			patient.chest_item_sewn = 0
 			return 1
 
 /* ---------- SCALPEL - IMPLANT ---------- */


### PR DESCRIPTION
Features added:

- Surgery (targeting chest)
-- Open a large chest incision with scalpel (grab).
--- If an unsecured item is in the chest, it will flop out onto the table.
-- Insert an item into the chest.
--- Any one holdable item can be inside a chest cavity at a time.
--- If an item is in the chest, it can be removed with scalpel (grab).
-- Sew the item in place with suture (help). (Optional)
-- Close the chest incision with suture (grab).

- Chest Item
-- Targeting the chest area of a person with a chest item and attacking will activate (attack_self) the item inside.
-- Farting will also activate the item.
--- Farting while the chest item is unsecured will cause item to be pooped out.
--- Pooped out items cause blunt and bleed damage the larger the item is.
--- Items that can cut or stab will sever the person's butt when the item exits. This also does extra butt damage.
-- Flipping with a beaker or similar reagent container as a chest item will dump the reagents into the person's body.

- Medical Observations
-- Using a medical analyzer on a person with a chest item will show a sizable foreign object is located in their chest.
-- Observing someone with their chest open from unfinished surgery will state that they have a gaping hole in their chest.