### PR TITLE
Add a taser to the Tier 1 military loot crate

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -143,7 +143,7 @@
 								items += pick(/obj/item/chem_grenade/incendiary, /obj/item/chem_grenade/cryo, /obj/item/chem_grenade/shock, /obj/item/chem_grenade/pepper, prob(10); /obj/item/chem_grenade/sarin)
 								item_amounts += 1
 				else
-					picker = rand(1,1)
+					picker = rand(1,2)
 					switch(picker)
 						if(1)
 							items += /obj/item/reagent_containers/glass/beaker/large/antitox
@@ -155,6 +155,9 @@
 							items += /obj/item/reagent_containers/glass/beaker/large/epinephrine
 							item_amounts += 1
 							items += /obj/item/reagent_containers/hypospray
+							item_amounts += 1
+						if(2)
+							items += /obj/item/gun/energy/taser_gun
 							item_amounts += 1
 
 			if(5)


### PR DESCRIPTION
As of the 2016 release, that crate only has one possible set of items, and I don't think it gained any over time, so here's a new one for it to have. Enjoy!

(also no idea what the no new line at end of file thing is about feel free to change that back to the way it was)