### PR TITLE
Spatial tear

### DIFF
--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -153,8 +153,8 @@
 			var/mob/living/M = A
 			if (istype(tear, /datum/spatial_tears/tear))
 				var/datum/spatial_tears/tear/T = tear
-				handle_teleport(T, M, OldLoc)
 				handle_damage(M)
+				handle_teleport(T, M, OldLoc)
 
 	//Handle assigning damage to various mobs that can pass through, currently only humans and cyborgs can pass
 	proc/handle_damage(mob/living/M)

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -8,13 +8,13 @@
 
 	event_effect(var/source)
 		..()
-		var/datum/spatial_tears/induvidual_tear/tear = new(source)
+		var/datum/spatial_tears/tear/tear = new(source)
 
 		spatial_tears.Add(tear)
 
 //Named so because I don't want this induvidual tear being triggered by events, 
 // and I didn't want to mess with the admin spawn and major events code. 
-/datum/spatial_tears/induvidual_tear
+/datum/spatial_tears/tear
 	//turfs North/East and South/West of corresponding tears stored for player teleportation
 	var/list/turfsSW = new()
 	var/list/turfsNE = new()
@@ -117,9 +117,9 @@
 	opacity = 1
 	density = 0
 	layer = NOLIGHT_EFFECTS_LAYER_BASE
-	var/datum/spatial_tears/induvidual_tear/tear
+	var/datum/spatial_tears/tear/tear
 
-	New(loc,duration, datum/spatial_tears/induvidual_tear/spatialTear)
+	New(loc,duration, datum/spatial_tears/tear/spatialTear)
 		..()
 		tear = spatialTear
 		spawn(duration)
@@ -137,8 +137,8 @@
 	HasEntered(atom/A, turf/OldLoc)
 		if (istype(A, /mob/living))
 			var/mob/living/M = A
-			if (istype(tear, /datum/spatial_tears/induvidual_tear))
-				var/datum/spatial_tears/induvidual_tear/T = tear
+			if (istype(tear, /datum/spatial_tears/tear))
+				var/datum/spatial_tears/tear/T = tear
 				handle_teleport(T, M, OldLoc)
 				handle_damage(M)
 
@@ -171,7 +171,7 @@
 
 
 	//Detemines which way to teleport the mob to
-	proc/handle_teleport(datum/spatial_tears/induvidual_tear/T, var/mob/living/M, var/turf/OldLoc)
+	proc/handle_teleport(datum/spatial_tears/tear/T, var/mob/living/M, var/turf/OldLoc)
 		if (T == null)
 			//Something's broken. Are there asset statements or error logs to print this error to?
 			return

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -52,6 +52,7 @@
 			remove_bad_turfs(turfsNE)
 
 		spawnCritters()
+
 	//loops through the list of all turfs and removes any that are dense or space
 	/proc/remove_bad_turfs(var/list/turfs)
 		for(var/turf/T in turfs)
@@ -60,9 +61,9 @@
 
 		return turfs
 
+	// selects a random amount of times to spawn critter
 	proc/spawnCritters()
-		var/amountSpawned = rand(2, 6)
-
+		var/amountSpawned = rand(4, 12)
 		while(amountSpawned > 0)
 			var/r = rand(0,1)
 			if (r && src.turfsNE && src.turfsNE.len > 0)
@@ -71,35 +72,36 @@
 				pick_critter_to_spawn(pick(src.turfsSW))
 			amountSpawned--
 
+	//
 	/proc/pick_critter_to_spawn(turf/T)
 		pick(
+			prob(10)
+				new /obj/critter/wendigo/king(T),
+			prob(20)
+				new /obj/critter/wendigo(T),
 			prob(30)
 				new /obj/critter/spider/spacerachnid(T),
+			prob(30)
 				new /obj/critter/spider/ice(T),
-				new /obj/critter/spider/ice/baby(T),
-				new /obj/critter/spider/ice/queen(T),
-			prob(20)
-				new /obj/critter/martian/psychic(T),
-				new /obj/critter/martian/sapper(T),
+			prob(40)
 				new /obj/critter/martian/soldier(T),
+			prob(40)
 				new /obj/critter/martian/warrior(T),
-			prob(40)
+			prob(50)
 				new /obj/critter/zombie(T),
-				new /obj/critter/zombie/scientist(T),
+			prob(50)
 				new /obj/critter/zombie/security(T),
-			prob(40)
-				new /obj/critter/wendigo(T),
-				new /obj/critter/wendigo/king(T),
+			prob(80)
 				new /obj/critter/bear(T),
 			prob(100)
 				new /obj/critter/floateye(T),
-				new /obj/critter/bat/buff(T),
-				new /obj/critter/domestic_bee(T),
+			prob(100)
 				new /obj/critter/spacebee(T),
 		)
 
 
-		//Can't get this to work, giving up, just doing the above
+		//originally wanted to pick from list of critters, but problems abound.
+		//leaving this here if someone more knowledgable than I wants to make it work
 		// var/datum/adventure_submode/critter/adv = new() // instantiating for statics grghhgh.
 		// var/type = pick(adv.critters)
 		// new type(T)

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -89,8 +89,6 @@
 	//
 	/proc/pick_critter_to_spawn(turf/T)
 		pick(
-			prob(10)
-				new /obj/critter/wendigo/king(T),
 			prob(20)
 				new /obj/critter/wendigo(T),
 			prob(30)
@@ -102,9 +100,7 @@
 			prob(40)
 				new /obj/critter/martian/warrior(T),
 			prob(50)
-				new /obj/critter/zombie(T),
-			prob(50)
-				new /obj/critter/zombie/security(T),
+				new /obj/critter/magiczombie(T), //Skeleton
 			prob(80)
 				new /obj/critter/bear(T),
 			prob(100)

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -1,16 +1,25 @@
-/datum/random_event/major/spatial_tear
+/datum/random_event/major/spatial_tear/spatial_tear
 	name = "Spatial Tear"
 	centcom_headline = "Spatial Anomaly"
 	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
 	required_elapsed_round_time = 6000 // 10m
+	var/list/spatial_tears = new()
+
+	event_effect(var/source)
+		..()
+		var/datum/random_event/major/spatial_tear/induvidual_tear/tear = new(source)
+
+		spatial_tears.Add(tear)
+
+
+/datum/random_event/major/spatial_tear/induvidual_tear
 
 	//turfs North/East and South/West of corresponding tears stored for player teleportation
 	var/list/turfsSW = new()
 	var/list/turfsNE = new()
 	var/btype
 
-	event_effect(var/source)
-		..()
+	New(var/source)
 		var/barrier_duration = rand(600, 3000)
 		var/pickx = rand(40,175)
 		var/picky = rand(75,140)
@@ -36,12 +45,6 @@
 				turfsSW.Add(locate(B.x, B.y-1, 1))
 				turfsNE.Add(locate(B.x, B.y+1, 1))
 
-
-	
-// /datum/random_event/major/spatial_tear/induvidual_tear
-// 	var/list/spatial_tears = new()
-
-
 /obj/forcefield/event
 	name = "Spatial Tear"
 	desc = "A breach in the spatial fabric. Extremely difficult to pass."
@@ -51,34 +54,25 @@
 	opacity = 1
 	density = 0
 	layer = NOLIGHT_EFFECTS_LAYER_BASE
-	var/datum/random_event/major/spatial_tear/tear
+	var/datum/random_event/major/spatial_tear/induvidual_tear/tear
 
-	New(loc,duration, datum/random_event/major/spatial_tear/spatialTear)
+	New(loc,duration, datum/random_event/major/spatial_tear/induvidual_tear/spatialTear)
 		..()
 		tear = spatialTear
 		spawn(duration)
 			qdel(src)
-			if (src.tear.turfsSW != null && src.tear.turfsNE != null)
+			// if (src.tear.turfsSW != null && src.tear.turfsNE != null)
 				//Remove corresponding teleport turfs
-				// src.tear.turfsSW.Remove(src)
-				// src.tear.turfsNE.Remove(src)
-
-
-	// CanPass(atom/A, turf/T)
-	// 	if (A.x)
-	// 	if (deployer == null) return 0
-	// 	if (deployer.power_level == 1 || deployer.power_level == 2)
-	// 		if (ismob(A)) return 1
-	// 		if (isobj(A)) return 1
-	// 	else return 0
+				 if (src.tear != null)
+				 	src.tear = null
 
 	HasEntered(atom/A, turf/OldLoc)
 
 		if (istype(A, /mob/living/carbon/human)/* && !locate(/obj/atmos_field, OldLoc)*/) // NOPE!! stepping around in the field while you're already inside it is fine
 			var/mob/living/carbon/human/M = A
 			// var/list/L = getTurfList(OldLoc)
-			if (istype(tear, /datum/random_event/major/spatial_tear))
-				var/datum/random_event/major/spatial_tear/T = tear
+			if (istype(tear, /datum/random_event/major/spatial_tear/induvidual_tear))
+				var/datum/random_event/major/spatial_tear/induvidual_tear/T = tear
 
 				if (T == null)
 					//Something's broken

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -45,6 +45,20 @@
 				turfsSW.Add(locate(B.x, B.y-1, 1))
 				turfsNE.Add(locate(B.x, B.y+1, 1))
 
+		if (turfsSW && turfsNE)
+			remove_bad_turfs(turfsSW)
+			remove_bad_turfs(turfsNE)
+
+	//loops through the list of all turfs and removes any that are dense or space
+	/proc/remove_bad_turfs(var/list/turfs)
+		for(var/turf/T in turfs)
+			if(istype(T,/turf/space) || (T.density)) continue
+				turfs.Remove(T)
+		
+		return turfs
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 /obj/forcefield/event
 	name = "Spatial Tear"
 	desc = "A breach in the spatial fabric. Extremely difficult to pass."
@@ -63,83 +77,85 @@
 			qdel(src)
 			// if (src.tear.turfsSW != null && src.tear.turfsNE != null)
 				//Remove corresponding teleport turfs
-				 if (src.tear != null)
-				 	src.tear = null
+			if (src.tear != null)
+				src.tear = null
 
 	HasEntered(atom/A, turf/OldLoc)
+		if (istype(A, /mob/living))
+			var/mob/living/M = A
 
-		if (istype(A, /mob/living/carbon/human)/* && !locate(/obj/atmos_field, OldLoc)*/) // NOPE!! stepping around in the field while you're already inside it is fine
-			var/mob/living/carbon/human/M = A
-			// var/list/L = getTurfList(OldLoc)
+			//Critters can't pass through the tear, unfair I know.
+			if (istype(A, /mob/living/critter))
+				return
+
 			if (istype(tear, /datum/random_event/major/spatial_tear/induvidual_tear))
 				var/datum/random_event/major/spatial_tear/induvidual_tear/T = tear
+				handle_teleport(T, M, OldLoc)
+				handle_damage(M)
+				//Considering making a human pick up a random item while passing through the tear. Like they got it in their travels inside.
 
-				if (T == null)
-					//Something's broken
-					return
 
-				if (T.btype == 1)
-					//user entered from the West
-					if (OldLoc.x < src.x)
-						teleport(M, T.turfsNE)
-					//user entered from the East
-					else
-						teleport(M, T.turfsSW)
-				else
-					//user entered from the South
-					if (OldLoc.y < src.y)
-						teleport(M, T.turfsNE)
-					//user entered from the North
-					else
-						teleport(M, T.turfsSW)
+	//Handle assigning damage to various mobs that can pass through, currently only humans and cyborgs can pass
+	proc/handle_damage(mob/living/M)
+		var/damage = rand(10, 30)
+		if (istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			H.remove_stamina(50)
+			var/damage_zone = pick(H.organs)
+			var/brute = 0
+			var/burn = 0
+			var/tox = 0
+			//brute damage most likely to be inflicted. 
+			//these could change, but I wanted it to be like anything could happen while crossing the tear
+			var/damage_type = pick(
+				prob(100)
+					brute = damage,
+				prob(75)
+					burn = damage,
+				prob(75)
+					tox = damage
+				)
+			H.TakeDamage(damage_zone, brute + damage_type, burn + damage_type, tox + damage_type, 0, 0)
+
+		else if (istype(M, /mob/living/silicon))
+			var/mob/living/silicon/robot/S = M
+			//stolen from robot.dm
+			for (var/obj/item/parts/robot_parts/RP in S.contents)
+				if (RP.ropart_take_damage(damage,damage) == 1) S.compborg_lose_limb(RP)
+
+
+	//Detemines which way to teleport the mob to
+	proc/handle_teleport(datum/random_event/major/spatial_tear/induvidual_tear/T, var/mob/living/M, var/turf/OldLoc)
+		if (T == null)
+			//Something's broken. Are there asset statements or error logs to print this error to?
+			return
+		if (T.btype == 1)
+			//user entered from the West
+			if (OldLoc.x < src.x)
+				teleport(M, T.turfsNE)
+			//user entered from the East
+			else
+				teleport(M, T.turfsSW)
+		else
+			//user entered from the South
+			if (OldLoc.y < src.y)
+				teleport(M, T.turfsNE)
+			//user entered from the North
+			else
+				teleport(M, T.turfsSW)
+
 
 	//Selects a random turf from the list and teleports the Human to that turf.
-	proc/teleport(mob/living/carbon/human/H as mob, var/list/L)
+	proc/teleport(mob/living/M as mob, var/list/L)
 		
-		playsound(H.loc, "sound/effects/mag_teleport.ogg", 25, 1, -1)
+		playsound(M.loc, "sound/effects/mag_teleport.ogg", 25, 1, -1)
 
 		var/turf/picked = null
 		if (L.len) 
 			picked = pick(L)
 		if(!isturf(picked))
-			boutput(H, "<span style=\"color:red\">You can't pass through, there must be nowhere to go.</span>")
+			boutput(M, "<span style=\"color:red\">You can't pass through, there must be nowhere to go.</span>")
 			return
 		
-		// animate_blink(H)
-		H.set_loc(picked)
-
-
-	//returns a list of turfs that can be teleported to
-	//turfs, not in space, on the tile across the spatial tear
-	// proc/getTurfList(var/turf/OldLoc as turf)
-	// 	//get a list of all atoms in on axis on the other side of the spatial tear
-	// 	var/list/L = null
-	// 	// Vertical
-	// 	if (tear.btype == 1)
-	// 		//user entered from the West                       world.icon_size
-	// 		if (OldLoc.x < src.x)
- //            	var/turf/Turf = locate(src.x+1, src.y, 1) //From_zone Turf
-
-	// 			L = bounds(src, 1, 4, 0, world.maxy-4)
-	// 		//user entered from the East
-	// 		else
-	// 			L = bounds(src, -1, 4, 0, world.maxy-4)
-	// 	else
-	// 		//user entered from the South
-	// 		if (OldLoc.y < src.y)
-	// 			L = bounds(src, 4, 1, world.maxx-4, 0)
-	// 		//user entered from the North
-	// 		else
-	// 			L = bounds(src, 4, -1, world.maxx-4, 0 )
-
-	// 	//search through list of atoms, and return list of Turfs not in space
-	// 	var/list/turfs = new/list()
-	// 	for(var/turf/T in L)
-	// 		if(istype(T,/turf/space)) continue
-	// 		if(T.density) continue
-	// 		if(T.x>world.maxx-4 || T.x<4)	continue	//putting them at the edge is dumb
-	// 		if(T.y>world.maxy-4 || T.y<4)	continue
-	// 		turfs.Add(T)
-
-	// 	return turfs
-
+		// animate_blink(M)
+		M.set_loc(picked)

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -4,25 +4,43 @@
 	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
 	required_elapsed_round_time = 6000 // 10m
 
+	//turfs North/East and South/West of corresponding tears stored for player teleportation
+	var/list/turfsSW = new()
+	var/list/turfsNE = new()
+	var/btype
+
 	event_effect(var/source)
 		..()
 		var/barrier_duration = rand(600, 3000)
 		var/pickx = rand(40,175)
 		var/picky = rand(75,140)
-		var/btype = rand(1,2)
+		btype = rand(1,2)
 		var/count = btype == 1 ? world.maxy : world.maxx // could just set it to our current mapsize (300) but this should help in case that changes again in the future or we go with non-square maps for some reason??  :v
 		if (btype == 1)
 			// Vertical
 			while (count > 0)
-				var/obj/forcefield/event/B = new /obj/forcefield/event(locate(pickx,count,1),barrier_duration)
+				var/obj/forcefield/event/B = new /obj/forcefield/event(locate(pickx,count,1),barrier_duration, src)
 				B.icon_state = "spat-v"
 				count -= 1
+				
+				turfsSW.Add(locate(B.x-1, B.y, 1))
+				turfsNE.Add(locate(B.x+1, B.y, 1))
+
 		else
 			// Horizontal
 			while (count > 0)
-				var/obj/forcefield/event/B = new /obj/forcefield/event(locate(count,picky,1),barrier_duration)
+				var/obj/forcefield/event/B = new /obj/forcefield/event(locate(count,picky,1),barrier_duration, src)
 				B.icon_state = "spat-h"
 				count -= 1
+
+				turfsSW.Add(locate(B.x, B.y-1, 1))
+				turfsNE.Add(locate(B.x, B.y+1, 1))
+
+
+	
+// /datum/random_event/major/spatial_tear/induvidual_tear
+// 	var/list/spatial_tears = new()
+
 
 /obj/forcefield/event
 	name = "Spatial Tear"
@@ -31,10 +49,103 @@
 	icon_state = "spat-h"
 	anchored = 1.0
 	opacity = 1
-	density = 1
+	density = 0
 	layer = NOLIGHT_EFFECTS_LAYER_BASE
+	var/datum/random_event/major/spatial_tear/tear
 
-	New(var/loc,var/duration)
+	New(loc,duration, datum/random_event/major/spatial_tear/spatialTear)
 		..()
+		tear = spatialTear
 		spawn(duration)
 			qdel(src)
+			if (src.tear.turfsSW != null && src.tear.turfsNE != null)
+				//Remove corresponding teleport turfs
+				// src.tear.turfsSW.Remove(src)
+				// src.tear.turfsNE.Remove(src)
+
+
+	// CanPass(atom/A, turf/T)
+	// 	if (A.x)
+	// 	if (deployer == null) return 0
+	// 	if (deployer.power_level == 1 || deployer.power_level == 2)
+	// 		if (ismob(A)) return 1
+	// 		if (isobj(A)) return 1
+	// 	else return 0
+
+	HasEntered(atom/A, turf/OldLoc)
+
+		if (istype(A, /mob/living/carbon/human)/* && !locate(/obj/atmos_field, OldLoc)*/) // NOPE!! stepping around in the field while you're already inside it is fine
+			var/mob/living/carbon/human/M = A
+			// var/list/L = getTurfList(OldLoc)
+			if (istype(tear, /datum/random_event/major/spatial_tear))
+				var/datum/random_event/major/spatial_tear/T = tear
+
+				if (T == null)
+					//Something's broken
+					return
+
+				if (T.btype == 1)
+					//user entered from the West
+					if (OldLoc.x < src.x)
+						teleport(M, T.turfsNE)
+					//user entered from the East
+					else
+						teleport(M, T.turfsSW)
+				else
+					//user entered from the South
+					if (OldLoc.y < src.y)
+						teleport(M, T.turfsNE)
+					//user entered from the North
+					else
+						teleport(M, T.turfsSW)
+
+	//Selects a random turf from the list and teleports the Human to that turf.
+	proc/teleport(mob/living/carbon/human/H as mob, var/list/L)
+		
+		playsound(H.loc, "sound/effects/mag_teleport.ogg", 25, 1, -1)
+
+		var/turf/picked = null
+		if (L.len) 
+			picked = pick(L)
+		if(!isturf(picked))
+			boutput(H, "<span style=\"color:red\">You can't pass through, there must be nowhere to go.</span>")
+			return
+		
+		// animate_blink(H)
+		H.set_loc(picked)
+
+
+	//returns a list of turfs that can be teleported to
+	//turfs, not in space, on the tile across the spatial tear
+	// proc/getTurfList(var/turf/OldLoc as turf)
+	// 	//get a list of all atoms in on axis on the other side of the spatial tear
+	// 	var/list/L = null
+	// 	// Vertical
+	// 	if (tear.btype == 1)
+	// 		//user entered from the West                       world.icon_size
+	// 		if (OldLoc.x < src.x)
+ //            	var/turf/Turf = locate(src.x+1, src.y, 1) //From_zone Turf
+
+	// 			L = bounds(src, 1, 4, 0, world.maxy-4)
+	// 		//user entered from the East
+	// 		else
+	// 			L = bounds(src, -1, 4, 0, world.maxy-4)
+	// 	else
+	// 		//user entered from the South
+	// 		if (OldLoc.y < src.y)
+	// 			L = bounds(src, 4, 1, world.maxx-4, 0)
+	// 		//user entered from the North
+	// 		else
+	// 			L = bounds(src, 4, -1, world.maxx-4, 0 )
+
+	// 	//search through list of atoms, and return list of Turfs not in space
+	// 	var/list/turfs = new/list()
+	// 	for(var/turf/T in L)
+	// 		if(istype(T,/turf/space)) continue
+	// 		if(T.density) continue
+	// 		if(T.x>world.maxx-4 || T.x<4)	continue	//putting them at the edge is dumb
+	// 		if(T.y>world.maxy-4 || T.y<4)	continue
+	// 		turfs.Add(T)
+
+	// 	return turfs
+

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -1,4 +1,4 @@
-/datum/random_event/major/spatial_tear/spatial_tear
+/datum/random_event/major/spatial_tear
 	name = "Spatial Tear"
 	centcom_headline = "Spatial Anomaly"
 	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -152,7 +152,7 @@
 
 	//Handle assigning damage to various mobs that can pass through, currently only humans and cyborgs can pass
 	proc/handle_damage(mob/living/M)
-		var/damage = rand(5, 20)
+		var/damage = rand(10, 40)
 		if (istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			H.remove_stamina(50)
@@ -162,11 +162,11 @@
 			var/tox = 0
 			pick(
 				prob(100)
-					brute = damage,
+					brute = do_brute_and_sever(H, damage),
 				prob(75)
 					burn = damage,
 				prob(75)
-					tox = damage
+					tox = damage,
 				)
 			H.TakeDamage(damage_zone, brute, burn, tox, 0, 0)
 
@@ -177,6 +177,31 @@
 			for (var/obj/item/parts/robot_parts/RP in S.contents)
 				if (RP.ropart_take_damage(damage,damage) == 1) S.compborg_lose_limb(RP)
 
+	//limb loss stolen from bigfart.dm
+	//I couldn't find any proc for a mob that sever's a limb that you provide, if such a thing exists then this should be removed since copying code is bad,
+	//but this works for severing a limb for now and adding a proc to human.dm for removing a limb is beyond the scope of changing spatial tears.
+	proc/do_brute_and_sever(mob/living/carbon/human/H, var/damage)
+		var/list/possible_limbs = list()
+		var/static/limbloss_prob = 50
+
+		if (H.limbs.l_arm)
+			possible_limbs += H.limbs.l_arm
+		if (H.limbs.r_arm)
+			possible_limbs += H.limbs.r_arm
+		if (H.limbs.l_leg)
+			possible_limbs += H.limbs.l_leg
+		if (H.limbs.r_leg)
+			possible_limbs += H.limbs.r_leg
+
+		if (possible_limbs.len)
+
+			//loop through, only sever one limb though, don't want to go too crazy
+			for (var/obj/item/parts/P in possible_limbs)
+				if (prob(limbloss_prob))
+					H.show_text("Your [P] was severed while trying to cross the Spatial Tear!", "red")
+					P.sever()
+					break;
+		return damage
 
 	//Detemines which way to teleport the mob to
 	proc/handle_teleport(datum/spatial_tears/tear/T, var/mob/living/M, var/turf/OldLoc)

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -1,16 +1,16 @@
 //make new even, multiple tears, single tear. and change name of induvidual tear to tear
-/datum/random_event/major/spatial_tears
+/datum/random_event/major/spatial_tear
 	name = "Spatial Tear"
 	centcom_headline = "Spatial Anomaly"
 	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
 	required_elapsed_round_time = 6000 // 10m
-	var/list/spatial_tears = new()
+	var/list/tears = new()
 
 	event_effect(var/source)
 		..()
 		var/datum/spatial_tears/tear/tear = new(source)
 
-		spatial_tears.Add(tear)
+		tears.Add(tear)
 
 //Named so because I don't want this induvidual tear being triggered by events, 
 // and I didn't want to mess with the admin spawn and major events code. 

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -1,4 +1,18 @@
 //make new even, multiple tears, single tear. and change name of induvidual tear to tear
+/datum/random_event/major/spatial_tears
+	name = "Multiple Spatial Tears"
+	centcom_headline = "Spatial Anomaly"
+	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
+	required_elapsed_round_time = 6000 // 10m
+	var/list/tears = new()
+
+	event_effect(var/source)
+		..()
+		var/r = rand(3, 7)
+		for (var/i = 0 to r)
+			var/datum/spatial_tears/tear/tear = new(source)
+			tears.Add(tear)
+
 /datum/random_event/major/spatial_tear
 	name = "Spatial Tear"
 	centcom_headline = "Spatial Anomaly"

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -1,4 +1,4 @@
-//make new even, multiple tears, single tear. and change name of induvidual tear to tear
+//makes multiple Spatial Tears
 /datum/random_event/major/spatial_tears
 	name = "Multiple Spatial Tears"
 	centcom_headline = "Spatial Anomaly"
@@ -13,6 +13,7 @@
 			var/datum/spatial_tears/tear/tear = new(source)
 			tears.Add(tear)
 
+//makes a single spatial tear
 /datum/random_event/major/spatial_tear
 	name = "Spatial Tear"
 	centcom_headline = "Spatial Anomaly"
@@ -68,7 +69,7 @@
 		spawnCritters()
 
 	//loops through the list of all turfs and removes any that are dense or space
-	/proc/remove_bad_turfs(var/list/turfs)
+	proc/remove_bad_turfs(var/list/turfs)
 		for(var/turf/T in turfs)
 			if(istype(T,/turf/space) || (T.density))
 				turfs.Remove(T)
@@ -86,8 +87,7 @@
 				pick_critter_to_spawn(pick(src.turfsSW))
 			amountSpawned--
 
-	//
-	/proc/pick_critter_to_spawn(turf/T)
+	proc/pick_critter_to_spawn(turf/T)
 		pick(
 			prob(20)
 				new /obj/critter/wendigo(T),
@@ -109,13 +109,11 @@
 				new /obj/critter/spacebee(T),
 		)
 
-
 		//originally wanted to pick from list of critters, but problems abound.
 		//leaving this here if someone more knowledgable than I wants to make it work
 		// var/datum/adventure_submode/critter/adv = new() // instantiating for statics grghhgh.
 		// var/type = pick(adv.critters)
 		// new type(T)
-
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /obj/forcefield/event

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -2,7 +2,7 @@
 /datum/random_event/major/spatial_tears
 	name = "Multiple Spatial Tears"
 	centcom_headline = "Spatial Anomaly"
-	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
+	centcom_message = "A very severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
 	required_elapsed_round_time = 6000 // 10m
 	var/list/tears = new()
 

--- a/code/datums/randomevents/spatial_tear.dm
+++ b/code/datums/randomevents/spatial_tear.dm
@@ -92,6 +92,8 @@
 			prob(20)
 				new /obj/critter/wendigo(T),
 			prob(30)
+				new /obj/critter/maneater(T);
+			prob(30)
 				new /obj/critter/spider/spacerachnid(T),
 			prob(30)
 				new /obj/critter/spider/ice(T),


### PR DESCRIPTION
Changes to Spatial Tears that will make them more interesting than a line of impassable terrain. 

Humans and Sillicons that move through it will take damage and be deposited on a random turf(non-space and non-dense) on the other side.

A small amount of critters will spawn on random tiles adjacent to the spatial tear when it is created.