### PR TITLE
Make hitting people with food possible

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -85,7 +85,7 @@
 	..()
 
 /obj/item/proc/Eat(var/mob/M as mob, var/mob/user)
-	if (!src.edible)
+	if (!src.edible || (user.a_intent == INTENT_HARM))
 		return 0
 	if (!iscarbon(M) && !istype(M, /mob/living/critter))
 		return 0


### PR DESCRIPTION
With this patch, if you're on Harm intent and you click on someone with a food item, you punch them with it instead of forcefeeding them.