### PR TITLE
Manufacturer screen update

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -288,19 +288,32 @@
 			dat += "<small>"
 			if (src.category != "Downloaded")
 				for(var/datum/manufacture/A in src.available)
+					var/list/mats_used = material_check(A)
+
 					if (istext(src.search) && !findtext(A.name, src.search, 1, null))
 						continue
 					else if (istext(src.category) && src.category != A.category)
 						continue
-					dat += "<BR><A href='?src=\ref[src];disp=\ref[A]'><b><u>[A.name]</u></b></A> "
+					
+					if (isnull(mats_used))
+						dat += "<BR><font color = 'red'>><b><u>[A.name]</u></b></font> "		//change this name to red if can't be made
+						// dat += "<BR><font color = 'red'><A href='?src=\ref[src];disp=\ref[A]'><b><u>[A.name]</u></b></A></font> "		//change this name to red if can't be made
+					else
+						dat += "<BR><A href='?src=\ref[src];disp=\ref[A]'><b><u>[A.name]</u></b></A> "		//change this name to red if can't be made
+
 					if (istext(A.category))
 						dat += "([A.category])"
 					dat += "<br>"
+
 					var/list_count = 1
 					for (var/X in A.item_paths)
 						if (list_count != 1) dat += ", "
-						dat += "[A.item_amounts[list_count]] [A.item_names[list_count]]"
+						if(X in mats_used)
+							dat += "[A.item_amounts[list_count]] [A.item_names[list_count]]"		//change this line to red if mising <font color = "red">
+						else
+							dat += "<font color = 'red'>[A.item_amounts[list_count]] [A.item_names[list_count]]</font>"		//change this line to red if mising <font color = "red">					
 						list_count++
+
 					if (A.time == 0 || src.speed == 0)
 						dat += "<br><b>Time:</b> ERROR<br>"
 					else

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -297,32 +297,21 @@
 					
 					if (isnull(mats_used))
 						dat += "<BR><font color = 'red'><b><u>[A.name]</u></b></font> "		//change this name to red if can't be made
-						// dat += "<BR><font color = 'red'><A href='?src=\ref[src];disp=\ref[A]'><b><u>[A.name]</u></b></A></font> "		//change this name to red if can't be made
 					else
 						dat += "<BR><A href='?src=\ref[src];disp=\ref[A]'><b><u>[A.name]</u></b></A> "		//change this name to normal if available
 
 					if (istext(A.category))
 						dat += "([A.category])"
 					dat += "<br>"
-					src.visible_message("\n[A.name]")
-					src.visible_message("mats_Used =[mats_used]")
-
-					for (var/i in mats_used)
-						src.visible_message("		=[i]")
 
 					var/list_count = 1
 					for (var/X in A.item_paths)
 						if (list_count != 1) dat += ", "
-						src.visible_message("X = [X] -------  item_name = [A.item_names[list_count]]")
 
 						var/found = 0
+						var/list/usable_materials = get_mat_ids(A)
 
-						//we have hte MET-1 paths in X
-						var/inner_list_count = 1
-						
-						var/list/usable_materials = material_check1(A)
 						//get all mat_ids in this manufacturable	needed to get the actual material to use in the material pattern match
-
 						for (var/mat_id in usable_materials)
 							if (usable_materials[mat_id] < A.item_amounts[list_count])
 								continue
@@ -330,16 +319,6 @@
 							if (match_material_pattern(X, mat))
 								found = 1
 								break
-				// var/found = 0
-				// for (var/mat_id in usable_materials)
-				// 	var/available = usable_materials[mat_id]
-				// 	if (available < amount)
-				// 		continue
-				// 	var/datum/material/mat = getCachedMaterial(mat_id)
-				// 	if (match_material_pattern(pattern, mat))
-				// 		materials[i] = mat_id
-				// 		found = 1
-				// 		break
 
 						var/datum/material/mat = getCachedMaterial(A.item_names[list_count])
 						if (found)
@@ -1105,9 +1084,8 @@
 			return 1
 		return 0
 
-//////////////////////////////////////////////////
-//new get all mat_ids with which to grab /datum/materials for the match method // for a datum/manufacture
-	proc/material_check1(datum/manufacture/M)
+	//return list of all mat_ids of a manufacturable 
+	proc/get_mat_ids(datum/manufacture/M)
 		var/list/usable = src.contents
 		var/list/usable_materials = cuttings.Copy()
 		for (var/obj/item/I in usable)
@@ -1116,7 +1094,6 @@
 
 		return usable_materials
 
-/////////////////////////////////////////////////////
 	proc/material_check(datum/manufacture/M)
 		var/list/usable = src.contents
 		var/list/materials = list()
@@ -1150,8 +1127,6 @@
 				if (!found)
 					return
 		return materials
-
-////////////////////////////////////////////////////
 
 	proc/add_and_get_similar_materials(var/obj/item/material_piece/M,var/amount_needed)
 		if (!istype(M) || !M.material || !isnum(amount_needed))

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -320,7 +320,6 @@
 								found = 1
 								break
 
-						var/datum/material/mat = getCachedMaterial(A.item_names[list_count])
 						if (found)
 							dat += "[A.item_amounts[list_count]] [A.item_names[list_count]]"		//change this line to red if mising <font color = "red">
 						else
@@ -1097,11 +1096,8 @@
 	proc/material_check(datum/manufacture/M)
 		var/list/usable = src.contents
 		var/list/materials = list()
-		var/list/usable_materials = cuttings.Copy()
+		var/list/usable_materials = get_mat_ids(M)
 		materials.len = M.item_paths.len
-		for (var/obj/item/I in usable)
-			if (istype(I, src.base_material_class) && I.material)
-				usable_materials[I.material.mat_id] += 10
 
 		for (var/i = 1; i <= M.item_paths.len; i++)
 			var/pattern = M.item_paths[i]


### PR DESCRIPTION
Small update to manufacturer's html screens.
- Hyperlinks no longer work for manufacturable items that don't have enough materials to build. The text is now red.
- The required materials section underneath manufacturable items now is a bit more helpful. Materials that the manufacturer doesn't have available, now display in red lettering and materials that are available still use the current black.
