### PR TITLE
change variable name in mob/living/silicon/robot.dm to fix compiler errors in byond 512.1453

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1355,7 +1355,7 @@
 					logTheThing("combat", user, src, "removes %target%'s brain at [log_loc(src)].") // Should be logged, really (Convair880).
 
 					src.uneq_active()
-					for (var/obj/item/roboupgrade/UP in src.contents) UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/upgrade in src.contents) upgrade.upgrade_deactivate(src)
 
 					// Stick the player (if one exists) in a ghost mob
 					if (src.mind)
@@ -1377,8 +1377,8 @@
 					logTheThing("combat", user, src, "removes %target%'s ai_interface at [log_loc(src)].")
 
 					src.uneq_active()
-					for (var/obj/item/roboupgrade/UP in src.contents)
-						UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/upgrade in src.contents)
+						upgrade.upgrade_deactivate(src)
 
 					user.put_in_hand_or_drop(src.ai_interface)
 					src.ai_interface = null
@@ -1391,17 +1391,17 @@
 						available_ai_shells -= src
 
 				if ("Remove an Upgrade")
-					var/obj/item/roboupgrade/UP = input("Which upgrade do you want to remove?", "Cyborg Maintenance") in src.upgrades
+					var/obj/item/roboupgrade/upgrade = input("Which upgrade do you want to remove?", "Cyborg Maintenance") in src.upgrades
 
-					if (!UP) return
+					if (!upgrade) return
 					if (get_dist(src.loc,user.loc) > 2 && (!src.bioHolder || !user.bioHolder.HasEffect("telekinesis")))
 						boutput(user, "<span style=\"color:red\">You need to move closer!</span>")
 						return
 
-					UP.upgrade_deactivate(src)
-					user.show_text("[UP] was removed!", "red")
-					src.upgrades.Remove(UP)
-					user.put_in_hand_or_drop(UP)
+					upgrade.upgrade_deactivate(src)
+					user.show_text("[upgrade] was removed!", "red")
+					src.upgrades.Remove(upgrade)
+					user.put_in_hand_or_drop(upgrade)
 
 					hud.update_upgrades()
 
@@ -1422,7 +1422,7 @@
 					if (!src.cell)
 						return
 
-					for (var/obj/item/roboupgrade/UP in src.contents) UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/upgrade in src.contents) upgrade.upgrade_deactivate(src)
 					user.put_in_hand_or_drop(src.cell)
 					user.show_text("You remove [src.cell] from [src].", "red")
 					src.show_text("Your power cell was removed!", "red")
@@ -2919,8 +2919,8 @@
 		new /obj/item/roboupgrade/fireshield(src)
 		new /obj/item/roboupgrade/teleport(src)
 
-		for(var/obj/item/roboupgrade/UP in src.contents)
-			src.upgrades.Add(UP)
+		for(var/obj/item/roboupgrade/upgrade in src.contents)
+			src.upgrades.Add(upgrade)
 
 		..()
 


### PR DESCRIPTION
The variable "var/obj/item/roboupgrade/UP" used several times in this file sometimes causes problems where the compiler reads it as a number instead of as text(and variable names can't start with numbers in byond) in the newest byond release, 512.1453

Best I can figure, this is an encoding issue with the machine trying to build (because not everyone gets this error), but changing the name will fix it just as well

This is just a simple find and replace in the file, changing all instances of a variable named "UP" to "upgrade".