### PR TITLE
Allow neutral pronoun usage in character setup screen

### DIFF
--- a/code/datums/genetics/bioHolder.dm
+++ b/code/datums/genetics/bioHolder.dm
@@ -34,7 +34,8 @@ var/list/datum/bioEffect/bioEffectList = list()
 	var/mob/owner = null
 	var/mob/parentHolder = null
 
-	var/gender = NEUTER
+	var/gender = MALE
+	var/pronouns = 0		//1 if using neutral pronouns (they/their);  0 if using gendered pronouns matching their gender var
 
 	proc/CopyOther(var/datum/appearanceHolder/toCopy)
 		//Copies settings of another given holder. Used for the bioholder copy proc and such things.
@@ -55,6 +56,7 @@ var/list/datum/bioEffect/bioEffectList = list()
 		u_color = toCopy.u_color
 
 		gender = toCopy.gender
+		pronouns = toCopy.pronouns
 		return
 
 	// Disabling this for now as I have no idea how to fit it into hex strings
@@ -81,6 +83,7 @@ var/list/datum/bioEffect/bioEffectList = list()
 
 		if (progress > 7 || prob(progress * 10))
 			gender = toCopy.gender
+			pronouns = toCopy.pronouns
 		return
 
 	proc/StaggeredCopyHex(var/hex, var/targetHex, var/adjust_denominator)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -159,6 +159,18 @@ datum/preferences
 		user << browse_rsc(icon(cursors_selection[target_cursor]), "tcursor.png")
 		user << browse_rsc(icon(hud_style_selection[hud_style], "preview"), "hud_preview.png")
 
+		var/display_gender = "Male"
+		if (!AH.pronouns)
+			if (src.gender == MALE)
+				display_gender = "Male (He/Him)"
+			else if (src.gender == FEMALE)
+				display_gender = "Female (She/Her)"
+		else
+			if (src.gender == MALE)
+				display_gender = "Male (They/Them)"
+			else if (src.gender == FEMALE)
+				display_gender = "Female (They/Them)"
+
 		var/dat = "<html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=8\"/></head><body><title>Character Setup</title>"
 
 		dat += "<b>Profile Name:</b> "
@@ -175,7 +187,7 @@ datum/preferences
 		dat += "(&reg; = <a href=\"byond://?src=\ref[user];preferences=1;b_random_look=1\">[src.be_random_look ? "Yes" : "No"]</a>)"
 		dat += "<br>"
 
-		dat += "<b>Gender:</b> <a href=\"byond://?src=\ref[user];preferences=1;gender=input\"><b>[src.gender == MALE ? "Male" : "Female"]</b></a><br>"
+		dat += "<b>Gender:</b> <a href=\"byond://?src=\ref[user];preferences=1;gender=input\"><b>[display_gender]</b></a><br>"
 		dat += "<b>Age:</b> <a href='byond://?src=\ref[user];preferences=1;age=input'>[src.age]</a><br>"
 		dat += "<b>Blood Type:</b> <a href='byond://?src=\ref[user];preferences=1;blType=input'>[src.random_blood ? "Random" : src.blType]</a><br>"
 		dat += "<b>Bank PIN:</b> <a href='byond://?src=\ref[user];preferences=1;pin=input'>[src.pin ? src.pin : "Random"]</a> (<a href=\"byond://?src=\ref[user];preferences=1;random_pin=1\">&reg;</a>)<br>"
@@ -778,12 +790,22 @@ datum/preferences
 				AH.u_color = new_ucolor
 
 		if (link_tags["gender"])
-			if (src.gender == MALE)
-				src.gender = FEMALE
-				AH.gender = FEMALE
+			if (!AH.pronouns)
+				if (src.gender == MALE)
+					src.gender = FEMALE
+					AH.gender = FEMALE
+				else if (src.gender == FEMALE)
+					src.gender = MALE
+					AH.gender = MALE
+					AH.pronouns = 1
 			else
-				src.gender = MALE
-				AH.gender = MALE
+				if (src.gender == MALE)
+					src.gender = FEMALE
+					AH.gender = FEMALE
+				else if (src.gender == FEMALE)
+					src.gender = MALE
+					AH.gender = MALE
+					AH.pronouns = 0
 
 		if (link_tags["changelog"])
 			src.view_changelog = !(src.view_changelog)

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -33,6 +33,7 @@ datum/preferences/proc/savefile_save(client/user, profileNum=1)
 	F["[profileNum]_job_prefs_3"] << src.jobs_low_priority
 	F["[profileNum]_job_prefs_4"] << src.jobs_unwanted
 	if (src.AH)
+		F["[profileNum]_neutral_pronouns"] << AH.pronouns
 		F["[profileNum]_eye_color"] << AH.e_color
 		F["[profileNum]_hair_color"] << AH.customization_first_color
 		F["[profileNum]_facial_color"] << AH.customization_second_color
@@ -154,6 +155,7 @@ datum/preferences/proc/savefile_load(client/user, var/profileNum = 1)
 	F["[profileNum]_job_prefs_3"] >> src.jobs_low_priority
 	F["[profileNum]_job_prefs_4"] >> src.jobs_unwanted
 	if (src.AH)
+		F["[profileNum]_neutral_pronouns"] >> AH.pronouns
 		F["[profileNum]_eye_color"] >> AH.e_color
 		F["[profileNum]_hair_color"] >> AH.customization_first_color
 		F["[profileNum]_facial_color"] >> AH.customization_second_color

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1355,7 +1355,7 @@
 					logTheThing("combat", user, src, "removes %target%'s brain at [log_loc(src)].") // Should be logged, really (Convair880).
 
 					src.uneq_active()
-					for (var/obj/item/roboupgrade/UP in src.contents) UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/UPGR in src.contents) UPGR.upgrade_deactivate(src)
 
 					// Stick the player (if one exists) in a ghost mob
 					if (src.mind)
@@ -1377,8 +1377,8 @@
 					logTheThing("combat", user, src, "removes %target%'s ai_interface at [log_loc(src)].")
 
 					src.uneq_active()
-					for (var/obj/item/roboupgrade/UP in src.contents)
-						UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/UPGR in src.contents)
+						UPGR.upgrade_deactivate(src)
 
 					user.put_in_hand_or_drop(src.ai_interface)
 					src.ai_interface = null
@@ -1391,17 +1391,17 @@
 						available_ai_shells -= src
 
 				if ("Remove an Upgrade")
-					var/obj/item/roboupgrade/UP = input("Which upgrade do you want to remove?", "Cyborg Maintenance") in src.upgrades
+					var/obj/item/roboupgrade/UPGR = input("Which upgrade do you want to remove?", "Cyborg Maintenance") in src.upgrades
 
-					if (!UP) return
+					if (!UPGR) return
 					if (get_dist(src.loc,user.loc) > 2 && (!src.bioHolder || !user.bioHolder.HasEffect("telekinesis")))
 						boutput(user, "<span style=\"color:red\">You need to move closer!</span>")
 						return
 
-					UP.upgrade_deactivate(src)
-					user.show_text("[UP] was removed!", "red")
-					src.upgrades.Remove(UP)
-					user.put_in_hand_or_drop(UP)
+					UPGR.upgrade_deactivate(src)
+					user.show_text("[UPGR] was removed!", "red")
+					src.upgrades.Remove(UPGR)
+					user.put_in_hand_or_drop(UPGR)
 
 					hud.update_upgrades()
 
@@ -1422,7 +1422,7 @@
 					if (!src.cell)
 						return
 
-					for (var/obj/item/roboupgrade/UP in src.contents) UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/UPGR in src.contents) UPGR.upgrade_deactivate(src)
 					user.put_in_hand_or_drop(src.cell)
 					user.show_text("You remove [src.cell] from [src].", "red")
 					src.show_text("Your power cell was removed!", "red")
@@ -2919,8 +2919,8 @@
 		new /obj/item/roboupgrade/fireshield(src)
 		new /obj/item/roboupgrade/teleport(src)
 
-		for(var/obj/item/roboupgrade/UP in src.contents)
-			src.upgrades.Add(UP)
+		for(var/obj/item/roboupgrade/UPGR in src.contents)
+			src.upgrades.Add(UPGR)
 
 		..()
 

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -500,6 +500,10 @@
 	if (!subject)
 		return "their"
 
+	//down here for clarity. check the mobs bioholder/appearanceholder to see if they want to use neutral pronouns
+	if (subject.bioHolder && subject.bioHolder.mobAppearance && subject.bioHolder.mobAppearance.pronouns)
+		return "their"
+
 	if (subject.gender == "male")
 		return "his"
 	else if (subject.gender == "female")
@@ -509,6 +513,9 @@
 
 /proc/him_or_her(var/mob/subject)
 	if (!subject)
+		return "their"
+
+	if (subject.bioHolder && subject.bioHolder.mobAppearance && subject.bioHolder.mobAppearance.pronouns)
 		return "their"
 
 	if (subject.gender == "male")
@@ -522,6 +529,9 @@
 	if (!subject)
 		return "they"
 
+	if (subject.bioHolder && subject.bioHolder.mobAppearance && subject.bioHolder.mobAppearance.pronouns)
+		return "they"
+
 	if (subject.gender == "male")
 		return "he"
 	else if (subject.gender == "female")
@@ -531,6 +541,9 @@
 
 /proc/himself_or_herself(var/mob/subject)
 	if (!subject)
+		return "themself"
+
+	if (subject.bioHolder && subject.bioHolder.mobAppearance && subject.bioHolder.mobAppearance.pronouns)
 		return "themself"
 
 	if (subject.gender == "male")


### PR DESCRIPTION
adds a boolean var called "pronouns" onto appearanceHolder to denote if the character wants to use neutral pronouns (they/them) for the mob procs he_she, etc.

robot.dm still has that change in here. Lately I've just cherry-picked that commit for these branches I use because I had some weirdness with my branches that I started before I pulled that change and can't be bothered to look up how to fix it. 