### PR TITLE
Attach synth limbs

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1355,7 +1355,7 @@
 					logTheThing("combat", user, src, "removes %target%'s brain at [log_loc(src)].") // Should be logged, really (Convair880).
 
 					src.uneq_active()
-					for (var/obj/item/roboupgrade/UP in src.contents) UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/UPGR in src.contents) UPGR.upgrade_deactivate(src)
 
 					// Stick the player (if one exists) in a ghost mob
 					if (src.mind)
@@ -1377,8 +1377,8 @@
 					logTheThing("combat", user, src, "removes %target%'s ai_interface at [log_loc(src)].")
 
 					src.uneq_active()
-					for (var/obj/item/roboupgrade/UP in src.contents)
-						UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/UPGR in src.contents)
+						UPGR.upgrade_deactivate(src)
 
 					user.put_in_hand_or_drop(src.ai_interface)
 					src.ai_interface = null
@@ -1391,17 +1391,17 @@
 						available_ai_shells -= src
 
 				if ("Remove an Upgrade")
-					var/obj/item/roboupgrade/UP = input("Which upgrade do you want to remove?", "Cyborg Maintenance") in src.upgrades
+					var/obj/item/roboupgrade/UPGR = input("Which upgrade do you want to remove?", "Cyborg Maintenance") in src.upgrades
 
-					if (!UP) return
+					if (!UPGR) return
 					if (get_dist(src.loc,user.loc) > 2 && (!src.bioHolder || !user.bioHolder.HasEffect("telekinesis")))
 						boutput(user, "<span style=\"color:red\">You need to move closer!</span>")
 						return
 
-					UP.upgrade_deactivate(src)
-					user.show_text("[UP] was removed!", "red")
-					src.upgrades.Remove(UP)
-					user.put_in_hand_or_drop(UP)
+					UPGR.upgrade_deactivate(src)
+					user.show_text("[UPGR] was removed!", "red")
+					src.upgrades.Remove(UPGR)
+					user.put_in_hand_or_drop(UPGR)
 
 					hud.update_upgrades()
 
@@ -1422,7 +1422,7 @@
 					if (!src.cell)
 						return
 
-					for (var/obj/item/roboupgrade/UP in src.contents) UP.upgrade_deactivate(src)
+					for (var/obj/item/roboupgrade/UPGR in src.contents) UPGR.upgrade_deactivate(src)
 					user.put_in_hand_or_drop(src.cell)
 					user.show_text("You remove [src.cell] from [src].", "red")
 					src.show_text("Your power cell was removed!", "red")
@@ -2919,8 +2919,8 @@
 		new /obj/item/roboupgrade/fireshield(src)
 		new /obj/item/roboupgrade/teleport(src)
 
-		for(var/obj/item/roboupgrade/UP in src.contents)
-			src.upgrades.Add(UP)
+		for(var/obj/item/roboupgrade/UPGR in src.contents)
+			src.upgrades.Add(UPGR)
 
 		..()
 

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -147,16 +147,24 @@
 				O.show_message("<span style=\"color:red\">[attacher] attaches [src] to \his own stump[both_legs? "s" : ""]!</span>", 1)
 			else
 				O.show_message("<span style=\"color:red\">[attachee] has [src] attached to \his stump[both_legs? "s" : ""] by [attacher].</span>", 1)
-
-		if(attachee != attacher)
-			boutput(attachee, "<span style=\"color:red\">[attacher] attaches [src] to your stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")
-			boutput(attacher, "<span style=\"color:red\">You attach [src] to [attachee]'s stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")
-		else
-			boutput(attacher, "<span style=\"color:red\">You attach [src] to your own stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")
-
+		
 		attachee.set_body_icon_dirty()
-		spawn(rand(150,200))
-			if(remove_stage == 2) src.remove()
+
+		if (istype(src, /obj/item/parts/human_parts/leg/left/synth) || istype(src, /obj/item/parts/human_parts/arm/right/synth) || istype(src, /obj/item/parts/human_parts/arm/left/synth) || istype(src, /obj/item/parts/human_parts/leg/right/synth))
+			if(attachee != attacher)
+				boutput(attachee, "<span style=\"color:red\">[attacher] attaches [src] to your stump[both_legs? "s" : ""]. Roots fuse with the muscle and tendons!</span>")
+				boutput(attacher, "<span style=\"color:red\">You attach [src] to [attachee]'s stump[both_legs? "s" : ""]. Roots fuse with the muscle and tendons!</span>")
+			else
+				boutput(attacher, "<span style=\"color:red\">You attach [src] to your own stump[both_legs? "s" : ""]. Roots fuse with the muscle and tendons!</span>")
+		else
+			if(attachee != attacher)
+				boutput(attachee, "<span style=\"color:red\">[attacher] attaches [src] to your stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")
+				boutput(attacher, "<span style=\"color:red\">You attach [src] to [attachee]'s stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")
+			else
+				boutput(attacher, "<span style=\"color:red\">You attach [src] to your own stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")
+
+			spawn(rand(150,200))
+				if(remove_stage == 2) src.remove()
 
 		return
 

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -51,8 +51,10 @@
 		if(user.zone_sel.selecting != slot || !ishuman(M))
 			return ..()
 
-		if(!(locate(/obj/machinery/optable, M.loc) && M.lying) && !(locate(/obj/table, M.loc) && (M.paralysis || M.stat)) && !(M.reagents && M.reagents.get_reagent_amount("ethanol") > 10 && M == user))
-			return ..()
+		//if it's not a snyth limb, we need to do actual surgery
+		if (!istype(src, /obj/item/parts/human_parts/leg/left/synth) || !istype(src, /obj/item/parts/human_parts/arm/right/synth) || !istype(src, /obj/item/parts/human_parts/arm/left/synth) || !istype(src, /obj/item/parts/human_parts/leg/right/synth))
+			if(!(locate(/obj/machinery/optable, M.loc) && M.lying) && !(locate(/obj/table, M.loc) && (M.paralysis || M.stat)) && !(M.reagents && M.reagents.get_reagent_amount("ethanol") > 10 && M == user))
+				return ..()
 
 		var/mob/living/carbon/human/H = M
 

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -52,7 +52,7 @@
 			return ..()
 
 		//if it's not a snyth limb, we need to do actual surgery
-		if (!istype(src, /obj/item/parts/human_parts/leg/left/synth) || !istype(src, /obj/item/parts/human_parts/arm/right/synth) || !istype(src, /obj/item/parts/human_parts/arm/left/synth) || !istype(src, /obj/item/parts/human_parts/leg/right/synth))
+		if (!istype(src, /obj/item/parts/human_parts/leg/left/synth) && !istype(src, /obj/item/parts/human_parts/arm/right/synth) && !istype(src, /obj/item/parts/human_parts/arm/left/synth) && !istype(src, /obj/item/parts/human_parts/leg/right/synth))
 			if(!(locate(/obj/machinery/optable, M.loc) && M.lying) && !(locate(/obj/table, M.loc) && (M.paralysis || M.stat)) && !(M.reagents && M.reagents.get_reagent_amount("ethanol") > 10 && M == user))
 				return ..()
 


### PR DESCRIPTION
Attach synth limbs to a person missing a limb simply by attacking that person in the correct zone with the correct limb.

Sorry about robot.dm being in here. I thought I fixed that problem with my main branch but I guess I never did. I think I thought that it was fixed for all new branches and the latest patches I made were from old branches before I pulled that commit so yeah. I'll fix it for future patches.