### PR TITLE
Medium-tier science loot crate w/ High-Tier Medicine

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -43,10 +43,23 @@
 							items += /obj/item/device/voltron
 							item_amounts += 1
 				else if (tier == 2)
-					picker = rand(1,1)
+					picker = rand(1,2)
 					switch(picker)
 						if(1)
 							items += pick(/obj/critter/bear)
+							item_amounts += 1
+						else
+							items += /obj/item/reagent_containers/glass/beaker/large/salbutamol
+							item_amounts += 1
+							items += /obj/item/reagent_containers/glass/beaker/large/omnizine
+							item_amounts += 1
+							items += /obj/item/reagent_containers/glass/beaker/large/atropine
+							item_amounts += 1
+							items += /obj/item/reagent_containers/glass/beaker/large/pentetic_acid
+							item_amounts += 1
+							items += /obj/item/reagent_containers/glass/beaker/large/morphine
+							item_amounts += 1
+							items += /obj/item/reagent_containers/hypospray
 							item_amounts += 1
 				else
 					picker = rand(1,3)


### PR DESCRIPTION
Adds a second medium-tier science loot crate, alongside the existing bear-in-a-crate.

The crate contains a hypospray and 100u reserve tanks of the following reagents: Salbutamol, Omnizine, Atropine, Pentetic Acid, and Morphine.

Dependent on the following patch: https://github.com/goonstation/goonstation-2016/pull/112