### PR TITLE
Fixed certain projectiles in bullet.dm incorrectly reading the state …

### DIFF
--- a/code/datums/projectiles/bullet.dm
+++ b/code/datums/projectiles/bullet.dm
@@ -128,13 +128,13 @@ toxic - poisons
 	caliber = 0.308
 	icon_turf_hit = "bhole-small"
 
-	on_hit(atom/hit, dirflag)
+	on_hit(atom/hit, dirflag, obj/projectile/proj)
 		if(ishuman(hit))
 			var/mob/living/carbon/human/M = hit
-			if(power > 40)
+			if(proj.power > 40)
 				M.stunned += 3
 				M.weakened += 2
-			if(power > 80)
+			if(proj.power > 80)
 				var/turf/target = get_edge_target_turf(M, dirflag)
 				spawn(0)
 					M.throw_at(target, 2, 2)
@@ -218,13 +218,13 @@ toxic - poisons
 	implanted = /obj/item/implant/projectile/bullet_12ga
 	casing = /obj/item/casing/shotgun_red
 
-	on_hit(atom/hit, dirflag)
+	on_hit(atom/hit, dirflag, obj/projectile/proj)
 		if (ishuman(hit))
 			var/mob/living/carbon/human/M = hit
-			if(power > 30)
+			if(proj.power > 30)
 				M.stunned += 5
 				M.weakened += 5
-			if(power > 70)
+			if(proj.power > 70)
 				var/turf/target = get_edge_target_turf(M, dirflag)
 				spawn(0)
 					if(!M.stat) M.emote("scream")
@@ -263,10 +263,10 @@ toxic - poisons
 	icon_turf_hit = "bhole"
 	casing = /obj/item/casing/shotgun_blue
 
-	on_hit(atom/hit, dirflag)
+	on_hit(atom/hit, dirflag, obj/projectile/proj)
 		if (ishuman(hit))
 			var/mob/living/carbon/human/M = hit
-			if(power >= 16)
+			if(proj.power >= 16)
 				var/turf/target = get_edge_target_turf(M, dirflag)
 				spawn(0)
 					if(!M.stat) M.emote("scream")


### PR DESCRIPTION
…of the projectile's power.

Certain projectiles used conditional statements checking power, to see if the projectile has lost too much power. However, this was incorrectly defined and it was checking the power of /datum/projectile, rather than /obj/projectile. Because of this, these conditional expressions were always returning true.

The on_hit() proc defined in projectile_parent.dm has an argument for passing the /obj/projectile into the body of the proc. I have modified the on_hit() procs defined in the children of /datum/projectile/ to include this argument, so they can then check the power of /obj/projectile as the power of the projectile dissipates.

Note: There is a var in /datum/projectile called master that, in theory could also be used to access /obj/projectile. However, this var is never set in any of the procs in /datum/projectile. 