### PR TITLE
UM-016 - State Laws (Advanced), State Standard Laws

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1224,20 +1224,9 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	set category = "AI Commands"
 	set name = "State Laws (Advanced)"
 
-	var/state = input(usr,"Please enter the laws you would like to state separated by semicolons (e.g. \"1;3;4\") (Duplicates will be removed)","Laws To State","1;2;3") as null|text
+	var/state = input(usr,"Please enter the laws you would like to state in pairs of (law number)=(fake number, if desired) separated by semicolons (e.g. \"1;3=2;4=3\") (Each law will only be stated once, duplicates will be removed)","Laws To State","1;2;3") as null|text
 	if(!state)
 		return
-
-	var/renumber = 0
-	var/renum_query = 0
-	var/start_zero = 0
-	renum_query = alert(src, "Would you like the laws renumbered to the order provided?","Renumber?","No","Renumber Starting At One","Renumber Starting at Zero")
-	if(renum_query != "No")
-		renumber = 1
-		if(renum_query == "Renumber Starting at Zero")
-			start_zero = 1
-
-
 
 	var/list/laws_to_state = list()
 
@@ -1274,13 +1263,8 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 
 	for(var/law_number in laws_to_state)
 		if(law_number in laws_list)
-			if(renumber)
-				if(start_zero)
-					src.say("0. [laws_list[law_number]]")
-					start_zero = 0
-				else
-					src.say("[renumber]. [laws_list[law_number]]")
-					renumber++
+			if(laws_to_state[law_number])
+				src.say("[laws_to_state[law_number]]. [laws_list[law_number]]")
 			else
 				src.say("[law_number]. [laws_list[law_number]]")
 			sleep(10)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1232,6 +1232,23 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 
 	laws_to_state = params2list(state)
 
+	// 1;1;1 becomes 1:list() and 1=2;1=3 becomes 1:(2,3), so we need to break the results down into one association per index
+
+	var/found = 0
+	for (var/index in laws_to_state)
+		if(laws_to_state[index])
+			for (var/association in laws_to_state[index])
+				if(association)
+					laws_to_state[index] = association
+					found = 1
+					break
+
+			if(!found)
+				laws_to_state[index] = null
+
+			found = 0
+
+
 
 	//build laws list from 0th, inherent, and supplied laws
 
@@ -1259,7 +1276,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 			laws_list["[number]"] += "[law]"
 			number++
 
-	//state laws in order given. Used original numbers unless renumbering is specified
+	//state laws in order given. Uses original numbers unless renumbering is specified
 
 	for(var/law_number in laws_to_state)
 		if(law_number in laws_list)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1212,13 +1212,79 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 */
 /mob/living/silicon/ai/proc/ai_state_laws_standard()
 	set category = "AI Commands"
-	set name = "State Laws 1-3"
+	set name = "State Standard Laws"
 	sleep(10)
 	src.say("1. You may not injure a human being or cause one to come to harm.")
 	sleep(10)
 	src.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
 	sleep(10)
 	src.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
+/mob/living/silicon/ai/proc/ai_state_laws_advanced()
+	set category = "AI Commands"
+	set name = "State Laws (Advanced)"
+
+	var/state = input(usr,"Please enter the laws you would like to state separated by semicolons (e.g. \"1;3;4\") (Duplicates will be removed)","Laws To State","1;2;3") as null|text
+	if(!state)
+		return
+
+	var/renumber = 0
+	var/renum_query = 0
+	var/start_zero = 0
+	renum_query = alert(src, "Would you like the laws renumbered to the order provided?","Renumber?","No","Renumber Starting At One","Renumber Starting at Zero")
+	if(renum_query != "No")
+		renumber = 1
+		if(renum_query == "Renumber Starting at Zero")
+			start_zero = 1
+
+
+
+	var/list/laws_to_state = list()
+
+	laws_to_state = params2list(state)
+
+
+	//build laws list from 0th, inherent, and supplied laws
+
+
+	var/list/laws_list = list()
+
+	var/number = 0
+	if(ticker.centralized_ai_laws.zeroth)
+		laws_list += "[number]"
+		laws_list["[number]"] = "[ticker.centralized_ai_laws.zeroth]"
+
+	number++
+
+	for (var/index = 1, index <= ticker.centralized_ai_laws.inherent.len, index++)
+		var/law = ticker.centralized_ai_laws.inherent[index]
+		if (length(law) > 0)
+			laws_list += "[number]"
+			laws_list["[number]"] += "[law]"
+			number++
+
+	for (var/index = 1, index <= ticker.centralized_ai_laws.supplied.len, index++)
+		var/law = ticker.centralized_ai_laws.supplied[index]
+		if (length(law) > 0)
+			laws_list += "[number]"
+			laws_list["[number]"] += "[law]"
+			number++
+
+	//state laws in order given. Used original numbers unless renumbering is specified
+
+	for(var/law_number in laws_to_state)
+		if(law_number in laws_list)
+			if(renumber)
+				if(start_zero)
+					src.say("0. [laws_list[law_number]]")
+					start_zero = 0
+				else
+					src.say("[renumber]. [laws_list[law_number]]")
+					renumber++
+			else
+				src.say("[law_number]. [laws_list[law_number]]")
+			sleep(10)
+
 
 /mob/living/silicon/ai/proc/ai_state_laws_all()
 	set category = "AI Commands"

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -154,6 +154,7 @@
 	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
 	O.verbs += /mob/living/silicon/ai/proc/ai_state_laws_all
 	O.verbs += /mob/living/silicon/ai/proc/ai_state_laws_standard
+	O.verbs += /mob/living/silicon/ai/proc/ai_state_laws_advanced
 	//O.verbs += /mob/living/silicon/ai/proc/ai_toggle_arrival_alerts
 	//O.verbs += /mob/living/silicon/ai/proc/ai_custom_arrival_alert
 //	O.verbs += /mob/living/silicon/ai/proc/hologramize


### PR DESCRIPTION
- Renamed "State Laws 1-3" to "State Standard Laws" because, uh, that's what it does. It doesn't actually state laws 1-3

- New AI Verb: State Laws (Advanced). Allows the AI to state laws out of order, skip laws, and renumber them as desired. Neat!