### PR TITLE
Several little bugfixes

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -561,7 +561,7 @@
 							src.no_print_spam = world.time
 							spawn (50)
 								if (src)
-									new /obj/item/paper/manufacturer_blueprint(src.loc, M.name)
+									new /obj/item/paper/manufacturer_blueprint(src.loc, M)
 
 		updateDialog()
 	else

--- a/code/WorkInProgress/computer3/mainframe2/misc_terms.dm
+++ b/code/WorkInProgress/computer3/mainframe2/misc_terms.dm
@@ -3428,7 +3428,7 @@
 		if (src.active)
 			boutput(usr, "<span style=\"color:red\">You can't unload it while it's active!</span>")
 			return
-		for (var/O in src.contents) O.set_loc(over_object)
+		for (var/atom/movable/O in src.contents) O.set_loc(over_object)
 		src.visible_message("<b>[M.name]</b> unloads [src.name]!")
 		src.update_icon()
 

--- a/code/WorkInProgress/computer3/mainframe2/misc_terms.dm
+++ b/code/WorkInProgress/computer3/mainframe2/misc_terms.dm
@@ -3428,7 +3428,7 @@
 		if (src.active)
 			boutput(usr, "<span style=\"color:red\">You can't unload it while it's active!</span>")
 			return
-		for (var/obj/O in src.contents) O.set_loc(over_object)
+		for (var/O in src.contents) O.set_loc(over_object)
 		src.visible_message("<b>[M.name]</b> unloads [src.name]!")
 		src.update_icon()
 

--- a/code/WorkInProgress/computer3/mainframe2/telesci.dm
+++ b/code/WorkInProgress/computer3/mainframe2/telesci.dm
@@ -1037,7 +1037,7 @@ var/telesci_modifiers_set = 0
 				coord_update_flag = 0
 				message_host("command=teleman&args=-p [padNum] coords x=[xtarget] y=[ytarget] z=[ztarget]")
 
-			message_host("command=teleman&args=scan")
+			message_host("command=teleman&args=-p [padNum] scan")
 			src.updateUsrDialog(1)
 			return
 

--- a/code/datums/chemistry/Chemistry-Holder.dm
+++ b/code/datums/chemistry/Chemistry-Holder.dm
@@ -16,12 +16,12 @@
 
 var/list/datum/reagents/active_reagent_holders = list()
 
-proc/chem_helmet_check(mob/living/carbon/human/H)
+proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 	if(H.wear_mask)
-		boutput(H, "<span style=\"color:red\">Your mask protects you from the hot liquid!</span>")
+		boutput(H, "<span style=\"color:red\">Your mask protects you from the [what_liquid] liquid!</span>")
 		return 0
 	else if(H.head)
-		boutput(H, "<span style=\"color:red\">Your helmet protects you from the hot liquid!</span>")
+		boutput(H, "<span style=\"color:red\">Your helmet protects you from the [what_liquid] liquid!</span>")
 		return 0
 	return 1
 
@@ -422,13 +422,13 @@ datum
 					var/mob/living/carbon/human/H = A
 					if(istype(H))
 						if(total_temperature > H.base_body_temp + (H.temp_tolerance * 4) && !H.is_heat_resistant())
-							if (chem_helmet_check(H))
+							if (chem_helmet_check(H, "hot"))
 								boutput(H, "<span style=\"color:red\">You are scalded by the hot chemicals!</span>")
 								H.TakeDamage("head", 0, round(log(total_temperature / 50) * 10), 0, DAMAGE_BURN) // lol this caused brute damage
 								H.emote("scream")
 								H.bodytemperature += min(max((total_temperature - T0C) - 20, 5),500)
 						else if(total_temperature < H.base_body_temp - (H.temp_tolerance * 4) && !H.is_cold_resistant())
-							if (chem_helmet_check(H))
+							if (chem_helmet_check(H, "cold"))
 								boutput(H, "<span style=\"color:red\">You are frostbitten by the freezing cold chemicals!</span>")
 								H.TakeDamage("head", 0, round(log(T0C - total_temperature / 50) * 10), 0, DAMAGE_BURN)
 								H.emote("scream")

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -453,8 +453,8 @@
 		RHITM:layer = initial(RHITM:layer)
 
 	if(pickup && !src.r_hand)
-		pickup.set_loc(src)
-		src.r_hand = pickup
+		src.hand_attack(pickup)
+		//src.put_in_hand_or_drop(pickup, 1)
 
 	src.set_clothing_icon_dirty()
 

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -58,6 +58,7 @@
 	jetpack = 1
 	health = 40
 	self_destruct = 1
+	robot_talk_understand = 1
 
 	New()
 		..()

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -650,6 +650,8 @@ PIPE BOMBS + CONSTRUCTION
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (user.equipped() == src)
 			if (!src.state)
+				if (istype(target, /obj/item/storage)) // no blowing yourself up if you have full backpack
+					return
 				if (user.bioHolder && user.bioHolder.HasEffect("clumsy"))
 					boutput(user, "<span style=\"color:red\">Huh? How does this thing work?!</span>")
 					logTheThing("combat", user, null, "accidentally triggers [src] (clumsy bioeffect) at [log_loc(user)].")

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -164,6 +164,9 @@
 			else
 				src.do_brainmelt(user, 2)
 				return
+		else
+			src.do_brainmelt(user, 2)
+			return
 		else ..()
 
 	attack(mob/M as mob, mob/user as mob)

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -166,8 +166,7 @@
 				return
 		else
 			src.do_brainmelt(user, 2)
-			return
-		else ..()
+			..()
 
 	attack(mob/M as mob, mob/user as mob)
 		if (iswizard(user) && !iswizard(M) && M.stat != 2)

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -107,7 +107,7 @@
 				src.standImage.color = newrgb
 
 	surgery(var/obj/item/tool)
-		if(remove_stage > 1 && tool.type == /obj/item/staple_gun)
+		if(remove_stage > 1 && istype(tool, /obj/item/staple_gun))
 			remove_stage = 0
 
 		else if(remove_stage == 0 || remove_stage == 2)

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -75,7 +75,7 @@
 
 		var/wrong_tool = 0
 
-		if(remove_stage > 1 && tool.type == /obj/item/staple_gun)
+		if(remove_stage > 1 && istype(tool, /obj/item/staple_gun))
 			remove_stage = 0
 
 		else if(remove_stage == 0 || remove_stage == 2)

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -122,7 +122,7 @@
 			minutes = minutes < 10 ? "0[minutes]" : "[minutes]"
 			seconds = seconds < 10 ? "0[seconds]" : "[seconds]"
 
-			return "[minutes][seconds % 2 == 0 ? ":" : " "][seconds]"
+			return "[minutes]:[seconds]"
 
 	proc/get_time()
 		return max(((last_announcement + announcement_delay) - world.timeofday ) / 10, 0)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1537,7 +1537,9 @@
 	var/datum/manufacture/blueprint = null
 
 	New(var/loc,var/schematic = null)
-		if (!schematic)
+		if(istype(schematic, /datum/manufacture))
+			src.blueprint = schematic
+		else if (!schematic)
 			if (ispath(src.blueprint))
 				src.blueprint = get_schematic_from_path(src.blueprint)
 			else


### PR DESCRIPTION
-Teleporter Computer sends the scan signal to the correct telepad if the target telepad is changed.
-If you get frozen in an ice cube, someone loads that cube in an artlab machine and then you break out of the cube you can now be pulled out!
-If two items have the same name they will now work properly with the Ruckingeneur Kit (notable example - Construction Visualizer).
-Masks now say that they protect you from cold liquid if the liquid is cold (instead of saying that they protect you from hot liquid).
-Partial fix to allow regular staplers to be used for surgery (but more surgery has been added since 2016 so it's not a complete fix).
-Breaching charges now won't activate if you try to place them in full containers.
-Monkeys will now pick up items properly without cheating. This means that they get blased by the Staff of Cthulhu if they attempt to pick it up.
-AI Shells can now hear machinetalk / silicontalk / you kno what I mean.
-Announcement console's ":" in between seconds and minutes will not blink now as it looked bad.